### PR TITLE
imagemagick fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ MAINTAINER Radu Suciu <radusuciu@gmail.com>
 
 RUN apt-get update && apt-get -y install imagemagick
 
+# imagemagick fix
+USER root
+ADD imagemagick6_policy_fix.sh /
+RUN sh /imagemagick6_policy_fix.sh
+
 # Create user with non-root privileges
 RUN adduser --disabled-password --gecos '' cimage
 RUN chown -R cimage /home/cimage

--- a/imagemagick6_policy_fix.sh
+++ b/imagemagick6_policy_fix.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+cd /etc/ImageMagick-6/
+sed -i 's/rights="none" pattern="PDF"/rights="read|write" pattern="PDF"/' policy.xml


### PR DESCRIPTION
cimage@1e62df757868:~$ cat /etc/ImageMagick-6/policy.xml
........
  <!-- disable ghostscript format types -->
  <policy domain="coder" rights="none" pattern="PS" />
  <policy domain="coder" rights="none" pattern="EPS" />
  <policy domain="coder" **rights="read|write" pattern="PDF"** />
  <policy domain="coder" rights="none" pattern="XPS" />
</policymap>
cimage@1e62df757868:~$ exit

confirmed the change under the container.
